### PR TITLE
Switch to go 1.17

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -12,7 +12,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v2
       with:
-        go-version: 1.18
+        go-version: 1.17
 
     - name: golangci-lint
       uses: golangci/golangci-lint-action@v2

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/advbet/decimal
 
-go 1.18
+go 1.17
 
 require (
 	github.com/shopspring/decimal v1.3.1


### PR DESCRIPTION
Go was downgraded to 1.17 as not all golangci-lint rules work on 1.18.