### PR TITLE
Add NewFromRat helper function

### DIFF
--- a/decimal.go
+++ b/decimal.go
@@ -66,6 +66,12 @@ func ScaledVal(d newDecimal.Decimal, exp int) int64 {
 	return Rescale(d, int32(exp)).CoefficientInt64()
 }
 
+// NewFromRat returns a new Decimal from a big.Rat. The numerator and
+// denominator are divided and rounded to the given exponent.
+func NewFromRat(r *big.Rat, e int) newDecimal.Decimal {
+	return newDecimal.NewFromBigInt(r.Num(), 0).DivRound(newDecimal.NewFromBigInt(r.Denom(), 0), -int32(e))
+}
+
 // Rescale copied from `shopspring/decimal`
 func Rescale(d newDecimal.Decimal, exp int32) newDecimal.Decimal {
 	if d.Exponent() == exp {

--- a/decimal_test.go
+++ b/decimal_test.go
@@ -263,7 +263,7 @@ func TestFromInt(t *testing.T) {
 func TestFromRat(t *testing.T) {
 	tests := []struct {
 		rat      *big.Rat
-		exp      int32
+		exp      int
 		expected Number
 	}{
 		{
@@ -357,7 +357,7 @@ func TestFromRat(t *testing.T) {
 
 	for i, tt := range tests {
 		t.Run(fmt.Sprintf("test-%d", i), func(t *testing.T) {
-			actual := newDecimal.NewFromBigRat(tt.rat, -1*tt.exp)
+			actual := NewFromRat(tt.rat, tt.exp)
 			assert.Equalf(
 				t,
 				tt.expected,

--- a/decimal_test.go
+++ b/decimal_test.go
@@ -260,7 +260,7 @@ func TestFromInt(t *testing.T) {
 	assert.Equal(t, newDecimal.New(-5, 0), newDecimal.NewFromInt(-5))
 }
 
-func TestFromRat(t *testing.T) {
+func TestNewFromRat(t *testing.T) {
 	tests := []struct {
 		rat      *big.Rat
 		exp      int

--- a/go.mod
+++ b/go.mod
@@ -12,5 +12,3 @@ require (
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c // indirect
 )
-
-replace github.com/shopspring/decimal v1.3.1 => github.com/davseby/decimal v1.3.2-0.20220621180928-f3eac4fb6504

--- a/go.sum
+++ b/go.sum
@@ -1,9 +1,9 @@
 github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/davseby/decimal v1.3.2-0.20220621180928-f3eac4fb6504 h1:vWumGigQ/jN/f1wYh3oMoXPWHNV8PcN5NfZYUxqcrE8=
-github.com/davseby/decimal v1.3.2-0.20220621180928-f3eac4fb6504/go.mod h1:DKyhrW/HYNuLGql+MJL6WCR6knT2jwCFRcu2hWCYk4o=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/shopspring/decimal v1.3.1 h1:2Usl1nmF/WZucqkFZhnfFYxxxu8LG21F6nPQBE5gKV8=
+github.com/shopspring/decimal v1.3.1/go.mod h1:DKyhrW/HYNuLGql+MJL6WCR6knT2jwCFRcu2hWCYk4o=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5CcY=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=


### PR DESCRIPTION
This pull request drops the fork that we have created in favour of an utility function that does the same thing. The reasoning goes like this: it does not seem that the maintainer is interested and, furthermore, we wouldn't need to maintain a fork. 

In general, we should refactor code in such a way that would not need `Rat`. Afterwards, we will no longer need this function. 